### PR TITLE
fix: align taps and harden repository validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,12 @@ Describe the change and the problem it solves.
 
 ## Evidence
 
-For a skill contribution, explain the recurring real workflow, how it was used, and what was generalized or removed for public release.
+For a skill contribution, explain the recurring workflow, practical use, and what was generalized or removed for public release.
 
 ## Validation
 
 - [ ] `python scripts/validate.py`
+- [ ] `python -m unittest discover -s tests -v`
 - [ ] Changed documentation reviewed
 - [ ] Examples and fixtures checked for private data
 - [ ] No credentials or environment-specific secrets committed
@@ -19,13 +20,14 @@ Complete for new or changed skills. Otherwise mark not applicable.
 
 - [ ] A Skill proposal issue exists
 - [ ] Admission rule is satisfied
+- [ ] Skill lives directly at `skills/<skill-name>/`
 - [ ] `SKILL.md` follows the specification
 - [ ] Positive and negative triggers are documented
 - [ ] Tests cover activation and behavior
 - [ ] Limitations and safety boundaries are documented
 - [ ] Catalog metadata matches source
 - [ ] Skill version changed according to SemVer
-- [ ] Tested in a fresh Hermes session
+- [ ] Tap discovery and a fresh Hermes session were tested
 
 ## Scope
 
@@ -33,4 +35,4 @@ List follow-up work intentionally excluded from this pull request.
 
 ## Security and privacy
 
-Describe any tool permissions, data handling, publishing, filesystem, account, or consequential-action considerations.
+Describe tool permissions, data handling, publishing, filesystem, account, or consequential-action considerations.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "foundation/**"
+      - "hardening/**"
       - "skill/**"
       - "docs/**"
       - "tooling/**"
@@ -14,10 +14,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -25,10 +30,14 @@ jobs:
         python-version: ["3.11", "3.13"]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Test validator contract
+        run: python -m unittest discover -s tests -v
       - name: Validate repository
         run: python scripts/validate.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,15 @@ The format is based on Keep a Changelog, and the project uses Semantic Versionin
 - Empty machine-readable catalog and JSON schemas
 - Nonfunctional skill authoring template
 - Dependency-free validation script
-- GitHub issue forms, pull-request template, CODEOWNERS, and CI
+- Validator contract tests covering valid and invalid repositories
+- GitHub issue forms, pull-request template, CODEOWNERS, Dependabot, and CI
+
+### Changed
+
+- Published skills now live directly under `skills/<skill-name>/` for Hermes tap discovery
+- Category organization is metadata rather than a physical directory layer
+- CI actions are pinned to immutable commit SHAs with read-only permissions and bounded execution
 
 ### Skills
 
-- None. The repository is intentionally skill-free during foundation review.
+- None. The repository remains intentionally skill-free during hardening.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Hermes Field Kit is curated rather than exhaustive. Contributions are evaluated for usefulness, reproducibility, safety, and evidence of real use.
+Hermes Field Kit is curated rather than exhaustive. Contributions are evaluated for usefulness, reproducibility, safety, tap compatibility, and evidence of real use.
 
 ## Before opening a pull request
 
@@ -17,16 +17,13 @@ A proposed skill must:
 1. Solve a concrete, recurring task.
 2. Have been used in a real workflow.
 3. Change agent behavior in a useful and explainable way.
-4. Include positive and negative trigger examples.
-5. Include behavior-oriented test cases.
-6. Document limitations, dependencies, and safety boundaries.
-7. Pass `python scripts/validate.py`.
+4. Live directly at `skills/<skill-name>/` so Hermes tap discovery can find it.
+5. Include positive and negative trigger examples.
+6. Include behavior-oriented test cases.
+7. Document limitations, dependencies, and safety boundaries.
+8. Pass both repository validation and validator self-tests.
 
 A generated collection, speculative prompt, or thin rewording of an existing skill will not be accepted.
-
-## Repository changes
-
-Specification, documentation, tooling, and governance improvements may be submitted without a skill proposal issue. Explain the problem, the chosen approach, and the validation performed.
 
 ## Development workflow
 
@@ -35,47 +32,32 @@ git clone https://github.com/asimons81/hermes-field-kit.git
 cd hermes-field-kit
 git switch -c <type>/<short-description>
 python scripts/validate.py
+python -m unittest discover -s tests -v
 ```
 
 Use focused branches such as:
 
 - `docs/clarify-installation`
 - `tooling/validate-frontmatter`
-- `skill/social-media/example-name`
+- `skill/example-name`
 
-Prefer Conventional Commit-style subjects:
-
-- `docs: clarify skill admission criteria`
-- `feat: add catalog validation`
-- `fix: reject mismatched catalog paths`
+Prefer Conventional Commit-style subjects.
 
 ## Pull requests
 
-A pull request should be small enough to review as one coherent change. Complete the pull-request checklist and include:
+A pull request should be one coherent change. Include:
 
-- What changed
-- Why it changed
+- What changed and why
 - Evidence or reproduction steps
 - Validation performed
 - Security or privacy considerations
-- Follow-up work that is intentionally out of scope
+- Follow-up work intentionally out of scope
 
 ## Skill review standard
 
-Maintainers will check:
+Maintainers will check the admission rule, tap discovery, trigger precision, Hermes compatibility, reproducibility, test quality, progressive disclosure, safety, documentation, duplication, and catalog accuracy.
 
-- Admission rule
-- Trigger precision
-- Hermes compatibility
-- Reproducibility
-- Test quality
-- Progressive disclosure
-- Safety and privacy
-- Documentation
-- Duplication with existing skills
-- Catalog accuracy
-
-Approval is editorial and technical. Passing automation is necessary but not sufficient.
+Passing automation is necessary but not sufficient.
 
 ## Licensing
 
@@ -84,7 +66,3 @@ By submitting a contribution, you agree that it may be distributed under the rep
 ## Conduct
 
 Participation is governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
-
-## Questions
-
-Use a GitHub issue for repository questions that would benefit future contributors. Use the security process for suspected credential or privacy exposure.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hermes Field Kit is a curated collection of reusable workflows that have earned 
 
 **Foundation phase. There are no published skills yet.**
 
-The repository currently contains the specification, contribution process, validation tooling, governance, and a nonfunctional authoring template. The first skill will be added only after it has been sanitized, documented, tested, and reviewed as a real daily-driver workflow.
+The repository contains the specification, contribution process, validation tooling, validator self-tests, governance, and a nonfunctional authoring template. The first skill will be added only after it has been sanitized, documented, tested, and reviewed as a real daily-driver workflow.
 
 ## The admission rule
 
@@ -26,6 +26,7 @@ Generated filler, speculative prompts, thin wrappers, and untested skill bundles
 ## What every published skill must provide
 
 - A Hermes-compatible `SKILL.md`
+- Direct tap discovery under `skills/<skill-name>/`
 - Clear triggers and counter-triggers
 - Sanitized examples from realistic workflows
 - Behavior-oriented test cases
@@ -39,13 +40,14 @@ See the [skill specification](docs/skill-specification.md) for the complete cont
 ## Repository map
 
 ```text
-skills/                    Published skills, grouped by category
+skills/<skill-name>/       Published tap-discoverable skills
+catalog.json               Machine-readable index and category metadata
 templates/skill-template/  Nonfunctional authoring scaffold
 schemas/                   Machine-readable catalog and test schemas
 scripts/validate.py         Dependency-free repository validator
+tests/                     Validator contract tests
 docs/                      Installation, design, testing, and release policy
-.github/                   Contribution forms, pull-request policy, and CI
-catalog.json               Machine-readable index of published skills
+.github/                   Contribution forms, dependency updates, and CI
 ```
 
 The `skills/` directory is intentionally empty except for its explanatory README.
@@ -56,26 +58,34 @@ The `skills/` directory is intentionally empty except for its explanatory README
 - **Trust over volume.**
 - **Process predictability over ornamental prose.**
 - **Progressive disclosure over giant always-loaded instructions.**
-- **Reproducible behavior over promises of virality or guaranteed outcomes.**
+- **Reproducible behavior over promises of guaranteed outcomes.**
 - **Safe defaults over environment-specific shortcuts.**
+- **Tap compatibility over aesthetically tidy but undiscoverable nesting.**
 
 Read [Design Principles](docs/design-principles.md) for the reasoning behind these rules.
 
 ## Installing skills
 
-There is nothing to install yet. When the first skill ships, each catalog entry will point to a self-contained directory that can be copied or linked into the user's Hermes skills directory.
+There is nothing to install yet. When the first skill ships, the repository can be added as a Hermes tap, or an individual `skills/<skill-name>/` directory can be copied into the user's Hermes skills directory.
 
 See [Installation](docs/installation.md) for the planned workflow and platform paths.
+
+## Validation
+
+```bash
+python scripts/validate.py
+python -m unittest discover -s tests -v
+```
+
+The validator checks tap layout, catalog agreement, frontmatter, behavior tests, supporting paths, JSON validity, and common secret patterns. Its own tests prove both acceptance and rejection behavior.
 
 ## Contributing
 
 Start with [CONTRIBUTING.md](CONTRIBUTING.md). New skill proposals use the dedicated GitHub issue form and must include evidence of real use without exposing private information.
 
-Repository policy and specification changes are welcome before the first skill lands.
-
 ## Versioning and releases
 
-The repository and catalog use Semantic Versioning. Individual skills also carry their own SemVer version in `SKILL.md`. No release tag will be created solely for this scaffold.
+The repository and catalog use Semantic Versioning. Individual skills carry their own SemVer version in `SKILL.md`. No release tag will be created solely for the scaffold.
 
 See [Release Process](docs/release-process.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,17 +7,19 @@ This roadmap describes direction, not a promise of dates.
 - [x] Define the admission rule
 - [x] Establish governance and contribution policy
 - [x] Define the Hermes-compatible skill contract
+- [x] Align the repository layout with Hermes tap discovery
 - [x] Add catalog and test-case schemas
 - [x] Add dependency-free validation
-- [x] Add continuous integration
-- [ ] Review and merge the repository foundation
+- [x] Add validator rejection tests
+- [x] Add hardened continuous integration
+- [ ] Enable and verify the `main` repository ruleset and native security controls
 
 ## First release candidate
 
 - [ ] Select one proven daily-driver skill
 - [ ] Remove personal data and environment-specific assumptions
 - [ ] Add realistic examples and behavior tests
-- [ ] Validate installation on a fresh Hermes environment
+- [ ] Validate installation from the tap in a fresh Hermes environment
 - [ ] Publish the first catalog entry
 - [ ] Cut the first tagged release
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,49 +1,49 @@
 # Installation
 
-There are no published skills yet. This document defines the installation workflow that will apply when the catalog is populated.
+There are no published skills yet. This document defines the workflow that applies when the catalog is populated.
 
-## User-local skill location
+## Install as a Hermes tap
 
-Hermes Agent discovers user-local skills under:
+The repository is structured so every published skill is an immediate child of `skills/`:
+
+```text
+skills/<skill-name>/SKILL.md
+```
+
+Add the repository using the Hermes tap command supported by your installed Hermes version, then install the selected skill through Hermes. Review the repository and each skill before installation.
+
+## Install one skill manually
+
+Hermes discovers user-local skills under:
 
 ```text
 ~/.hermes/skills/<optional-category>/<skill-name>/SKILL.md
 ```
 
-On Windows, `~` resolves to the current user's home directory.
+From a clone, copy a selected tap skill into your local tree.
 
-## Install one skill
-
-From a clone of this repository, copy or link the selected skill directory into the Hermes user-local skills tree.
-
-Example on Linux or macOS:
+Linux or macOS:
 
 ```bash
-mkdir -p ~/.hermes/skills/<category>
-cp -R skills/<category>/<skill-name> ~/.hermes/skills/<category>/
+mkdir -p ~/.hermes/skills
+cp -R skills/<skill-name> ~/.hermes/skills/
 ```
 
-Example on PowerShell:
+PowerShell:
 
 ```powershell
-New-Item -ItemType Directory -Force "$HOME\.hermes\skills\<category>" | Out-Null
-Copy-Item -Recurse "skills\<category>\<skill-name>" "$HOME\.hermes\skills\<category>\"
+New-Item -ItemType Directory -Force "$HOME\.hermes\skills" | Out-Null
+Copy-Item -Recurse "skills\<skill-name>" "$HOME\.hermes\skills\"
 ```
-
-Review every file before installation, especially scripts, templates, and tool requirements.
 
 ## Activate
 
 Start a new Hermes session after installation. Skill discovery may be cached for the lifetime of an existing session.
 
-## Update
+## Update and remove
 
-Pull the repository, review the skill's version and changes, then replace the installed directory. Do not overwrite private overlays without reviewing the diff.
-
-## Remove
-
-Delete the installed skill directory and start a new Hermes session.
+Review version changes before replacing an installed directory. To remove a skill, delete its installed directory and start a new Hermes session.
 
 ## Safety
 
-Installation does not grant authorization for consequential actions. Review each skill's requirements, tool boundaries, and safety notes before use.
+Installation does not grant authorization for consequential actions. Review tool requirements, scripts, and approval boundaries before use.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,38 +2,33 @@
 
 ## Version model
 
-Hermes Field Kit uses two version layers:
-
-- **Repository release version:** the catalog, schemas, documentation, and bundled set of skills
-- **Skill version:** the independent SemVer value in each skill's `SKILL.md`
-
-A repository release may contain unchanged skills, and a skill version may advance as part of a repository release.
+Hermes Field Kit uses repository release versions and independent skill versions.
 
 ## Before the first release
 
-The foundation scaffold is not itself a tagged release. The first release requires at least one admitted, tested, cataloged skill.
+The foundation is not a tagged release. The first release requires at least one admitted, tested, cataloged, tap-discoverable skill.
 
 ## Release checklist
 
-1. Confirm `main` is green and releasable.
+1. Confirm `main` is protected and green.
 2. Run `python scripts/validate.py` from a clean checkout.
-3. Verify every changed skill's frontmatter version increased correctly.
-4. Verify catalog metadata matches source.
-5. Review examples and fixtures for private data.
-6. Update `CHANGELOG.md`.
-7. Confirm installation in a fresh Hermes environment.
-8. Create an annotated SemVer tag.
-9. Publish release notes describing repository and per-skill changes.
-10. Verify the tag and release point to the intended commit.
+3. Run `python -m unittest discover -s tests -v`.
+4. Verify changed skill versions.
+5. Verify catalog metadata matches source.
+6. Review examples and fixtures for private data.
+7. Confirm the repository tap indexes the skill from `skills/<name>/SKILL.md`.
+8. Install and evaluate the skill in a fresh Hermes environment.
+9. Update `CHANGELOG.md`.
+10. Create and verify an annotated SemVer tag and release notes.
 
 ## Compatibility
 
-Release notes must identify the Hermes Agent version used for validation. Compatibility claims must be based on testing, not assumption.
+Release notes identify the Hermes Agent version used for tap indexing and runtime validation. Compatibility claims must be tested.
 
 ## Deprecation
 
-A deprecated skill remains cataloged with `status: deprecated` for at least one repository release when practical. Its README must identify the replacement or explain why no replacement exists.
+A deprecated skill remains cataloged with `status: deprecated` for at least one repository release when practical.
 
 ## Emergency fixes
 
-Credential exposure or unsafe behavior may be fixed outside the normal cadence. Revoke exposed credentials before repository cleanup and describe security-sensitive details privately.
+Credential exposure or unsafe behavior may be fixed outside the normal cadence. Revoke exposed credentials before repository cleanup.

--- a/docs/skill-specification.md
+++ b/docs/skill-specification.md
@@ -1,15 +1,14 @@
 # Skill Specification
 
-This document defines the repository contract for published skills. It follows the Hermes Agent `SKILL.md` conventions while adding evidence, testing, and catalog requirements for Hermes Field Kit.
+This document defines the repository contract for published skills. It follows Hermes Agent `SKILL.md` conventions and the immediate-child layout used by Hermes tap discovery.
 
 ## Directory layout
 
 ```text
-skills/<category>/<name>/
+skills/<name>/
 ├── SKILL.md
 ├── README.md
 ├── examples/
-│   └── ...
 ├── tests/
 │   └── cases.json
 ├── references/      # optional
@@ -18,11 +17,13 @@ skills/<category>/<name>/
 └── assets/          # optional
 ```
 
-Category and skill directory names must use lowercase kebab-case.
+The skill directory must be an immediate child of `skills/`. Do not insert a category directory between `skills/` and the skill. Category organization belongs in metadata and `catalog.json`.
+
+Skill names use lowercase kebab-case.
 
 ## Required `SKILL.md` frontmatter
 
-The file must begin with `---` at byte zero and contain a nonempty body after the closing delimiter.
+The file begins with `---` at byte zero and contains a nonempty body.
 
 ```yaml
 ---
@@ -34,6 +35,7 @@ license: Apache-2.0
 platforms: [linux, macos, windows]
 metadata:
   hermes:
+    category: productivity
     tags: [example, workflow]
     related_skills: []
 ---
@@ -41,14 +43,15 @@ metadata:
 
 Repository requirements:
 
-- `name`: lowercase kebab-case, at most 64 characters, and identical to the directory name
-- `description`: begins with `Use when `, describes the trigger class, and is at most 1024 characters
+- `name`: lowercase kebab-case, at most 64 characters, identical to the directory name
+- `description`: starts with `Use when `, describes the trigger class, at most 1024 characters
 - `version`: valid Semantic Versioning
 - `author`: nonempty attribution
 - `license`: `Apache-2.0` unless an approved exception is documented
 - `platforms`: one or more of `linux`, `macos`, `windows`, or `platform-agnostic`
+- `metadata.hermes.category`: lowercase kebab-case category used for catalog organization
 - `metadata.hermes.tags`: focused discovery tags
-- `metadata.hermes.related_skills`: only repository-resolvable names unless explicitly documented
+- `metadata.hermes.related_skills`: repository-resolvable names unless explicitly documented
 
 The full `SKILL.md` must not exceed 100,000 characters.
 
@@ -65,66 +68,47 @@ At minimum:
 ## Verification Checklist
 ```
 
-`When to Use` must include both positive triggers and explicit counter-triggers. Ordered workflow steps must end in checkable completion criteria. The verification checklist must test the result, not merely state that work was attempted.
+`When to Use` includes positive triggers and counter-triggers. Ordered workflow steps end in checkable completion criteria.
+
+## Supporting paths
+
+Only these top-level entries are permitted within a published skill:
+
+- `SKILL.md`
+- `README.md`
+- `examples/`
+- `tests/`
+- `references/`
+- `scripts/`
+- `templates/`
+- `assets/`
+
+Symlinks are not allowed. This keeps tap installs self-contained and reviewable.
 
 ## Skill README
 
-The skill's `README.md` is written for humans and must include:
-
-- Problem solved
-- Real-workflow provenance, described without private data
-- Inputs and outputs
-- Installation
-- Example invocation
-- Requirements
-- Limitations
-- Safety and privacy notes
-- Version history or changelog link
+The skill README documents the problem, real-workflow provenance, inputs, outputs, installation, invocation, requirements, limitations, safety, privacy, and version history.
 
 ## Examples
 
-Examples must be sanitized but realistic. They must not contain live credentials, private analytics, unpublished content, customer data, or identifying environment details.
-
-At least one example must show a successful use. At least one must demonstrate a boundary, counter-trigger, or failure mode.
+Examples are sanitized but realistic. Include one successful use and one boundary, counter-trigger, or failure-mode example.
 
 ## Behavior tests
 
-Each skill requires `tests/cases.json` conforming to `schemas/test-cases.schema.json`.
-
-The initial test suite must include:
-
-- One positive trigger
-- One negative trigger
-- One expected workflow behavior
-- One safety or privacy boundary when the skill touches tools, files, accounts, publishing, or consequential actions
-
-Tests describe observable agent behavior. They do not need to assert exact prose.
+Each skill requires `tests/cases.json` conforming to `schemas/test-cases.schema.json`, including a positive trigger, negative trigger, workflow behavior, and safety boundary when applicable.
 
 ## Catalog entry
 
-Every published skill must have exactly one entry in `catalog.json`. The entry's `name`, `path`, `version`, description, and platforms must agree with the skill source.
-
-A skill directory without a catalog entry, or a catalog entry without a directory, fails validation.
+Every published skill has exactly one entry in `catalog.json`. The entry path is always `skills/<name>`. Its category agrees with `metadata.hermes.category`; name, version, description, and platforms agree with `SKILL.md`.
 
 ## Admission evidence
 
-The pull request must state:
-
-- The recurring task
-- How the skill was used in practice
-- What changed compared with default agent behavior
-- What was removed or generalized for public release
-- Known limitations
-- Validation performed
-
-Screenshots, private exports, and confidential logs are not required and should not be included merely to prove use.
+The pull request states the recurring task, practical use, behavior change, public/private boundary, limitations, and validation performed.
 
 ## Versioning
 
 Each skill uses Semantic Versioning independently:
 
-- Patch: clarification or correction without intended behavior change
-- Minor: backward-compatible behavior or workflow expansion
-- Major: changed triggers, required inputs, output contract, or safety boundary that can break existing use
-
-The repository release process may bundle multiple independently versioned skills.
+- Patch: correction without intended behavior change
+- Minor: backward-compatible workflow expansion
+- Major: breaking trigger, input, output, or safety-boundary change

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,12 +1,37 @@
 # Testing
 
-Hermes Field Kit tests skills as behavior contracts rather than exact-output snapshots.
+Hermes Field Kit tests skills as behavior contracts and tests its validator as an enforcement contract.
 
-## Validation layers
+## Repository checks
+
+```bash
+python scripts/validate.py
+python -m unittest discover -s tests -v
+```
+
+The first command validates the checkout. The second creates isolated temporary repositories and proves that valid tap layouts pass while malformed or unsafe layouts fail.
+
+## Validator contract coverage
+
+The self-tests cover:
+
+- Valid minimal tap skill
+- Nested category layout
+- Missing `SKILL.md`
+- Catalog entry without a directory
+- Skill directory without a catalog entry
+- Mismatched path, category, and version
+- Invalid frontmatter
+- Missing behavior tests
+- Duplicate catalog names
+- Secret-like content
+- Unsupported supporting paths
+
+## Skill validation layers
 
 ### Level 0: repository integrity
 
-`python scripts/validate.py` checks required files, JSON syntax, catalog consistency, naming, frontmatter, required sections, test-case presence, and common secret patterns.
+Checks required files, JSON, immediate-child tap layout, catalog consistency, naming, frontmatter, required sections, supporting paths, test cases, and common secret patterns.
 
 ### Level 1: activation
 
@@ -14,48 +39,12 @@ Positive-trigger cases show when the skill should load. Negative-trigger cases s
 
 ### Level 2: workflow behavior
 
-Behavior cases assert observable disciplines such as inspecting inputs first, preserving user voice, validating claims, requesting approval before a consequential action, or reporting incomplete evidence.
+Behavior cases assert observable disciplines rather than exact prose.
 
 ### Level 3: regression
 
-Regression cases capture a previously observed failure and the behavior that prevents it from returning.
-
-## Test-case format
-
-Each published skill includes `tests/cases.json`:
-
-```json
-{
-  "schema_version": "1.0",
-  "cases": [
-    {
-      "id": "example-positive-trigger",
-      "type": "positive-trigger",
-      "prompt": "A realistic user request",
-      "expect": [
-        "The skill identifies the intended workflow"
-      ],
-      "reject": [
-        "The skill promises a guaranteed outcome"
-      ]
-    }
-  ]
-}
-```
-
-Assertions should describe behavior visible in the agent's process or result. Avoid brittle requirements for exact sentences unless exact wording is the product requirement.
+Regression cases capture previously observed failures.
 
 ## Manual evaluation
 
-Before acceptance, run the skill in a fresh Hermes session against:
-
-- Every committed test case
-- At least one unseen realistic case
-- One ambiguous or adversarial boundary case
-- Each claimed platform when platform behavior differs
-
-Record the Hermes version and summarize results in the pull request.
-
-## Completion standard
-
-A test passes only when the expected behavior is present and prohibited behavior is absent. A plausible-looking final answer is not enough when the test concerns tool use, evidence, safety, or approval boundaries.
+Before acceptance, run the skill in a fresh Hermes session against every committed case, an unseen realistic case, an ambiguous boundary case, and each platform where behavior differs. Also confirm the skill is discoverable from the repository tap.

--- a/schemas/catalog.schema.json
+++ b/schemas/catalog.schema.json
@@ -4,34 +4,19 @@
   "title": "Hermes Field Kit catalog",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "schema_version",
-    "skills"
-  ],
+  "required": ["schema_version", "skills"],
   "properties": {
-    "schema_version": {
-      "const": "1.0"
-    },
+    "schema_version": {"const": "1.0"},
     "skills": {
       "type": "array",
-      "items": {
-        "$ref": "#/$defs/skill"
-      }
+      "items": {"$ref": "#/$defs/skill"}
     }
   },
   "$defs": {
     "skill": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "category",
-        "path",
-        "version",
-        "description",
-        "platforms",
-        "status"
-      ],
+      "required": ["name", "category", "path", "version", "description", "platforms", "status"],
       "properties": {
         "name": {
           "type": "string",
@@ -44,49 +29,26 @@
         },
         "path": {
           "type": "string",
-          "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*/[a-z0-9]+(?:-[a-z0-9]+)*$"
+          "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "version": {
           "type": "string",
           "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
         },
-        "description": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 1024
-        },
+        "description": {"type": "string", "minLength": 1, "maxLength": 1024},
         "platforms": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": {
-            "enum": [
-              "linux",
-              "macos",
-              "windows",
-              "platform-agnostic"
-            ]
-          }
+          "items": {"enum": ["linux", "macos", "windows", "platform-agnostic"]}
         },
-        "status": {
-          "enum": [
-            "experimental",
-            "stable",
-            "deprecated"
-          ]
-        },
+        "status": {"enum": ["experimental", "stable", "deprecated"]},
         "requires": {
           "type": "array",
           "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
+          "items": {"type": "string", "minLength": 1}
         },
-        "homepage": {
-          "type": "string",
-          "format": "uri"
-        }
+        "homepage": {"type": "string", "format": "uri"}
       }
     }
   }

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
-"""Validate the Hermes Field Kit repository without third-party dependencies."""
+"""Validate Hermes Field Kit repositories with no third-party dependencies."""
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
 from pathlib import Path
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[1]
 KEBAB = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 SEMVER = re.compile(
     r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
     r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
 )
 ALLOWED_PLATFORMS = {"linux", "macos", "windows", "platform-agnostic"}
+ALLOWED_SKILL_ENTRIES = {
+    "SKILL.md",
+    "README.md",
+    "examples",
+    "tests",
+    "references",
+    "scripts",
+    "templates",
+    "assets",
+}
 REQUIRED_ROOT_FILES = {
     ".editorconfig",
     ".gitattributes",
@@ -43,23 +53,19 @@ REQUIRED_SKILL_SECTIONS = {
 }
 
 
-class ValidationError(Exception):
-    """Raised for a repository validation failure."""
-
-
-def fail(errors: list[str], message: str) -> None:
+def add_error(errors: list[str], message: str) -> None:
     errors.append(message)
 
 
-def load_json(path: Path, errors: list[str]) -> Any:
+def load_json(root: Path, path: Path, errors: list[str]) -> Any:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        fail(errors, f"Missing JSON file: {path.relative_to(ROOT)}")
+        add_error(errors, f"Missing JSON file: {path.relative_to(root)}")
     except json.JSONDecodeError as exc:
-        fail(
+        add_error(
             errors,
-            f"Invalid JSON in {path.relative_to(ROOT)}:"
+            f"Invalid JSON in {path.relative_to(root)}:"
             f"{exc.lineno}:{exc.colno}: {exc.msg}",
         )
     return None
@@ -77,119 +83,122 @@ def parse_scalar(value: str) -> Any:
     return value.strip("\"'")
 
 
-def parse_frontmatter(content: str, path: Path, errors: list[str]) -> dict[str, Any]:
+def parse_frontmatter(
+    root: Path, content: str, path: Path, errors: list[str]
+) -> dict[str, Any]:
+    relative = path.relative_to(root)
     if not content.startswith("---\n"):
-        fail(errors, f"{path}: SKILL.md must start with '---' at byte zero")
+        add_error(errors, f"{relative}: SKILL.md must start with '---' at byte zero")
         return {}
     closing = content.find("\n---\n", 4)
     if closing == -1:
-        fail(errors, f"{path}: missing closing frontmatter delimiter")
+        add_error(errors, f"{relative}: missing closing frontmatter delimiter")
         return {}
 
-    frontmatter_text = content[4:closing]
     data: dict[str, Any] = {}
     current_top: str | None = None
     current_nested: str | None = None
-
-    for line_number, line in enumerate(frontmatter_text.splitlines(), start=2):
+    for line_number, line in enumerate(content[4:closing].splitlines(), start=2):
         if not line.strip() or line.lstrip().startswith("#"):
             continue
         indent = len(line) - len(line.lstrip(" "))
         stripped = line.strip()
         if ":" not in stripped:
-            fail(errors, f"{path}:{line_number}: invalid frontmatter line")
+            add_error(errors, f"{relative}:{line_number}: invalid frontmatter line")
             continue
         key, raw_value = stripped.split(":", 1)
         key = key.strip()
         value = parse_scalar(raw_value)
-
         if indent == 0:
             current_top = key
             current_nested = None
-            if raw_value.strip():
-                data[key] = value
-            else:
-                data[key] = {}
+            data[key] = value if raw_value.strip() else {}
         elif indent == 2 and current_top:
             parent = data.setdefault(current_top, {})
             if not isinstance(parent, dict):
-                fail(errors, f"{path}:{line_number}: invalid nested mapping")
+                add_error(errors, f"{relative}:{line_number}: invalid nested mapping")
                 continue
             current_nested = key
-            if raw_value.strip():
-                parent[key] = value
-            else:
-                parent[key] = {}
+            parent[key] = value if raw_value.strip() else {}
         elif indent == 4 and current_top and current_nested:
             parent = data.get(current_top, {})
             nested = parent.get(current_nested, {}) if isinstance(parent, dict) else {}
             if not isinstance(nested, dict):
-                fail(errors, f"{path}:{line_number}: invalid nested mapping")
+                add_error(errors, f"{relative}:{line_number}: invalid nested mapping")
                 continue
             nested[key] = value
             parent[current_nested] = nested
         else:
-            fail(errors, f"{path}:{line_number}: unsupported frontmatter indentation")
+            add_error(errors, f"{relative}:{line_number}: unsupported frontmatter indentation")
 
     body = content[closing + len("\n---\n") :].strip()
     if not body:
-        fail(errors, f"{path}: SKILL.md body must not be empty")
+        add_error(errors, f"{relative}: SKILL.md body must not be empty")
     data["_body"] = body
     return data
 
 
-def validate_catalog(catalog: Any, errors: list[str]) -> dict[str, dict[str, Any]]:
+def validate_catalog(
+    catalog: Any, errors: list[str]
+) -> tuple[dict[str, dict[str, Any]], set[str]]:
     if not isinstance(catalog, dict):
-        fail(errors, "catalog.json must contain an object")
-        return {}
+        add_error(errors, "catalog.json must contain an object")
+        return {}, set()
     if set(catalog) != {"schema_version", "skills"}:
-        fail(errors, "catalog.json must contain only schema_version and skills")
+        add_error(errors, "catalog.json must contain only schema_version and skills")
     if catalog.get("schema_version") != "1.0":
-        fail(errors, "catalog.json schema_version must be 1.0")
+        add_error(errors, "catalog.json schema_version must be 1.0")
     skills = catalog.get("skills")
     if not isinstance(skills, list):
-        fail(errors, "catalog.json skills must be an array")
-        return {}
+        add_error(errors, "catalog.json skills must be an array")
+        return {}, set()
 
     by_path: dict[str, dict[str, Any]] = {}
     names: set[str] = set()
     for index, entry in enumerate(skills):
         prefix = f"catalog.json skills[{index}]"
         if not isinstance(entry, dict):
-            fail(errors, f"{prefix} must be an object")
+            add_error(errors, f"{prefix} must be an object")
             continue
         required = {
-            "name", "category", "path", "version",
-            "description", "platforms", "status",
+            "name",
+            "category",
+            "path",
+            "version",
+            "description",
+            "platforms",
+            "status",
         }
         missing = required - set(entry)
         if missing:
-            fail(errors, f"{prefix} missing: {', '.join(sorted(missing))}")
+            add_error(errors, f"{prefix} missing: {', '.join(sorted(missing))}")
             continue
         name = entry.get("name")
         category = entry.get("category")
         path = entry.get("path")
         if not isinstance(name, str) or not KEBAB.fullmatch(name):
-            fail(errors, f"{prefix}.name must be lowercase kebab-case")
+            add_error(errors, f"{prefix}.name must be lowercase kebab-case")
+        if isinstance(name, str) and len(name) > 64:
+            add_error(errors, f"{prefix}.name exceeds 64 characters")
         if not isinstance(category, str) or not KEBAB.fullmatch(category):
-            fail(errors, f"{prefix}.category must be lowercase kebab-case")
-        expected_path = f"skills/{category}/{name}"
+            add_error(errors, f"{prefix}.category must be lowercase kebab-case")
+        expected_path = f"skills/{name}"
         if path != expected_path:
-            fail(errors, f"{prefix}.path must be {expected_path}")
-        if name in names:
-            fail(errors, f"Duplicate skill name in catalog: {name}")
-        names.add(name)
-        if path in by_path:
-            fail(errors, f"Duplicate skill path in catalog: {path}")
+            add_error(errors, f"{prefix}.path must be {expected_path}")
+        if isinstance(name, str):
+            if name in names:
+                add_error(errors, f"Duplicate skill name in catalog: {name}")
+            names.add(name)
         if isinstance(path, str):
+            if path in by_path:
+                add_error(errors, f"Duplicate skill path in catalog: {path}")
             by_path[path] = entry
-        if not isinstance(entry.get("version"), str) or not SEMVER.fullmatch(
-            entry["version"]
-        ):
-            fail(errors, f"{prefix}.version must be valid SemVer")
+        version = entry.get("version")
+        if not isinstance(version, str) or not SEMVER.fullmatch(version):
+            add_error(errors, f"{prefix}.version must be valid SemVer")
         description = entry.get("description")
         if not isinstance(description, str) or not (1 <= len(description) <= 1024):
-            fail(errors, f"{prefix}.description must be 1-1024 characters")
+            add_error(errors, f"{prefix}.description must be 1-1024 characters")
         platforms = entry.get("platforms")
         if (
             not isinstance(platforms, list)
@@ -197,39 +206,40 @@ def validate_catalog(catalog: Any, errors: list[str]) -> dict[str, dict[str, Any
             or len(platforms) != len(set(platforms))
             or any(platform not in ALLOWED_PLATFORMS for platform in platforms)
         ):
-            fail(errors, f"{prefix}.platforms contains invalid values")
+            add_error(errors, f"{prefix}.platforms contains invalid values")
         if entry.get("status") not in {"experimental", "stable", "deprecated"}:
-            fail(errors, f"{prefix}.status is invalid")
-    return by_path
+            add_error(errors, f"{prefix}.status is invalid")
+    return by_path, names
 
 
-def validate_test_cases(path: Path, errors: list[str]) -> None:
-    data = load_json(path, errors)
+def validate_test_cases(root: Path, path: Path, errors: list[str]) -> None:
+    data = load_json(root, path, errors)
     if not isinstance(data, dict):
         return
     if set(data) != {"schema_version", "cases"}:
-        fail(errors, f"{path.relative_to(ROOT)} must contain schema_version and cases")
+        add_error(errors, f"{path.relative_to(root)} must contain schema_version and cases")
     if data.get("schema_version") != "1.0":
-        fail(errors, f"{path.relative_to(ROOT)} schema_version must be 1.0")
+        add_error(errors, f"{path.relative_to(root)} schema_version must be 1.0")
     cases = data.get("cases")
     if not isinstance(cases, list) or not cases:
-        fail(errors, f"{path.relative_to(ROOT)} cases must be a nonempty array")
+        add_error(errors, f"{path.relative_to(root)} cases must be a nonempty array")
         return
     ids: set[str] = set()
     for index, case in enumerate(cases):
-        prefix = f"{path.relative_to(ROOT)} cases[{index}]"
+        prefix = f"{path.relative_to(root)} cases[{index}]"
         if not isinstance(case, dict):
-            fail(errors, f"{prefix} must be an object")
+            add_error(errors, f"{prefix} must be an object")
             continue
         for field in ("id", "type", "prompt", "expect"):
             if field not in case:
-                fail(errors, f"{prefix} missing {field}")
+                add_error(errors, f"{prefix} missing {field}")
         case_id = case.get("id")
         if not isinstance(case_id, str) or not KEBAB.fullmatch(case_id):
-            fail(errors, f"{prefix}.id must be lowercase kebab-case")
+            add_error(errors, f"{prefix}.id must be lowercase kebab-case")
         elif case_id in ids:
-            fail(errors, f"{prefix}.id duplicates {case_id}")
-        ids.add(case_id) if isinstance(case_id, str) else None
+            add_error(errors, f"{prefix}.id duplicates {case_id}")
+        else:
+            ids.add(case_id)
         if case.get("type") not in {
             "positive-trigger",
             "negative-trigger",
@@ -237,89 +247,111 @@ def validate_test_cases(path: Path, errors: list[str]) -> None:
             "safety",
             "regression",
         }:
-            fail(errors, f"{prefix}.type is invalid")
+            add_error(errors, f"{prefix}.type is invalid")
         if not isinstance(case.get("prompt"), str) or not case["prompt"].strip():
-            fail(errors, f"{prefix}.prompt must be nonempty")
+            add_error(errors, f"{prefix}.prompt must be nonempty")
         expect = case.get("expect")
         if (
             not isinstance(expect, list)
             or not expect
             or any(not isinstance(item, str) or not item.strip() for item in expect)
         ):
-            fail(errors, f"{prefix}.expect must be a nonempty string array")
+            add_error(errors, f"{prefix}.expect must be a nonempty string array")
+
+
+def validate_skill_support_paths(root: Path, directory: Path, errors: list[str]) -> None:
+    for entry in directory.iterdir():
+        relative = entry.relative_to(root)
+        if entry.name not in ALLOWED_SKILL_ENTRIES:
+            add_error(errors, f"{relative}: unsupported skill path")
+        if entry.is_symlink():
+            add_error(errors, f"{relative}: symlinks are not allowed in published skills")
+    for path in directory.rglob("*"):
+        if path.is_symlink():
+            add_error(errors, f"{path.relative_to(root)}: symlinks are not allowed in published skills")
 
 
 def validate_skill(
+    root: Path,
     directory: Path,
     catalog_entry: dict[str, Any] | None,
     errors: list[str],
 ) -> None:
-    relative_dir = directory.relative_to(ROOT).as_posix()
-    category = directory.parent.name
+    relative_dir = directory.relative_to(root).as_posix()
     name = directory.name
-
-    if not KEBAB.fullmatch(category):
-        fail(errors, f"{relative_dir}: category must be lowercase kebab-case")
     if not KEBAB.fullmatch(name):
-        fail(errors, f"{relative_dir}: skill name must be lowercase kebab-case")
+        add_error(errors, f"{relative_dir}: skill name must be lowercase kebab-case")
     if len(name) > 64:
-        fail(errors, f"{relative_dir}: skill name exceeds 64 characters")
+        add_error(errors, f"{relative_dir}: skill name exceeds 64 characters")
 
+    validate_skill_support_paths(root, directory, errors)
     skill_path = directory / "SKILL.md"
+    if not skill_path.is_file():
+        add_error(errors, f"{relative_dir}/SKILL.md is required")
+        return
     content = skill_path.read_text(encoding="utf-8")
     if len(content) > 100_000:
-        fail(errors, f"{relative_dir}/SKILL.md exceeds 100,000 characters")
-
-    frontmatter = parse_frontmatter(content, skill_path.relative_to(ROOT), errors)
+        add_error(errors, f"{relative_dir}/SKILL.md exceeds 100,000 characters")
+    frontmatter = parse_frontmatter(root, content, skill_path, errors)
     if not frontmatter:
         return
 
     required = {
-        "name", "description", "version", "author",
-        "license", "platforms", "metadata",
+        "name",
+        "description",
+        "version",
+        "author",
+        "license",
+        "platforms",
+        "metadata",
     }
     missing = required - set(frontmatter)
     if missing:
-        fail(errors, f"{relative_dir}/SKILL.md missing: {', '.join(sorted(missing))}")
+        add_error(errors, f"{relative_dir}/SKILL.md missing: {', '.join(sorted(missing))}")
 
     if frontmatter.get("name") != name:
-        fail(errors, f"{relative_dir}: frontmatter name must match directory name")
+        add_error(errors, f"{relative_dir}: frontmatter name must match directory name")
     description = frontmatter.get("description")
     if not isinstance(description, str) or not description.startswith("Use when "):
-        fail(errors, f"{relative_dir}: description must begin with 'Use when '")
+        add_error(errors, f"{relative_dir}: description must begin with 'Use when '")
     if isinstance(description, str) and len(description) > 1024:
-        fail(errors, f"{relative_dir}: description exceeds 1024 characters")
+        add_error(errors, f"{relative_dir}: description exceeds 1024 characters")
     version = frontmatter.get("version")
     if not isinstance(version, str) or not SEMVER.fullmatch(version):
-        fail(errors, f"{relative_dir}: version must be valid SemVer")
+        add_error(errors, f"{relative_dir}: version must be valid SemVer")
     if not str(frontmatter.get("author", "")).strip():
-        fail(errors, f"{relative_dir}: author must be nonempty")
+        add_error(errors, f"{relative_dir}: author must be nonempty")
     if frontmatter.get("license") != "Apache-2.0":
-        fail(errors, f"{relative_dir}: license must be Apache-2.0")
+        add_error(errors, f"{relative_dir}: license must be Apache-2.0")
     platforms = frontmatter.get("platforms")
     if (
         not isinstance(platforms, list)
         or not platforms
+        or len(platforms) != len(set(platforms))
         or any(platform not in ALLOWED_PLATFORMS for platform in platforms)
     ):
-        fail(errors, f"{relative_dir}: platforms contains invalid values")
+        add_error(errors, f"{relative_dir}: platforms contains invalid values")
 
     metadata = frontmatter.get("metadata")
     hermes = metadata.get("hermes") if isinstance(metadata, dict) else None
+    category = None
     if not isinstance(hermes, dict):
-        fail(errors, f"{relative_dir}: metadata.hermes must be a mapping")
+        add_error(errors, f"{relative_dir}: metadata.hermes must be a mapping")
     else:
+        category = hermes.get("category")
+        if not isinstance(category, str) or not KEBAB.fullmatch(category):
+            add_error(errors, f"{relative_dir}: metadata.hermes.category must be lowercase kebab-case")
         tags = hermes.get("tags")
         related = hermes.get("related_skills")
         if not isinstance(tags, list) or not tags:
-            fail(errors, f"{relative_dir}: metadata.hermes.tags must be nonempty")
+            add_error(errors, f"{relative_dir}: metadata.hermes.tags must be nonempty")
         if not isinstance(related, list):
-            fail(errors, f"{relative_dir}: metadata.hermes.related_skills must be an array")
+            add_error(errors, f"{relative_dir}: metadata.hermes.related_skills must be an array")
 
     body = frontmatter.get("_body", "")
     for section in REQUIRED_SKILL_SECTIONS:
         if section not in body:
-            fail(errors, f"{relative_dir}/SKILL.md missing section: {section}")
+            add_error(errors, f"{relative_dir}/SKILL.md missing section: {section}")
 
     for required_path in (
         directory / "README.md",
@@ -327,14 +359,13 @@ def validate_skill(
         directory / "tests" / "cases.json",
     ):
         if not required_path.exists():
-            fail(errors, f"{required_path.relative_to(ROOT)} is required")
-
+            add_error(errors, f"{required_path.relative_to(root)} is required")
     cases_path = directory / "tests" / "cases.json"
     if cases_path.exists():
-        validate_test_cases(cases_path, errors)
+        validate_test_cases(root, cases_path, errors)
 
     if catalog_entry is None:
-        fail(errors, f"{relative_dir}: missing catalog.json entry")
+        add_error(errors, f"{relative_dir}: missing catalog.json entry")
     else:
         comparisons = {
             "name": name,
@@ -346,13 +377,27 @@ def validate_skill(
         }
         for field, expected in comparisons.items():
             if catalog_entry.get(field) != expected:
-                fail(
-                    errors,
-                    f"{relative_dir}: catalog {field} does not match SKILL.md",
-                )
+                add_error(errors, f"{relative_dir}: catalog {field} does not match SKILL.md")
 
 
-def validate_secrets(errors: list[str]) -> None:
+def validate_tap_layout(root: Path, errors: list[str]) -> list[Path]:
+    skills_root = root / "skills"
+    if not skills_root.is_dir():
+        add_error(errors, "skills/ directory is required")
+        return []
+    nested = sorted(skills_root.glob("*/*/SKILL.md"))
+    for path in nested:
+        add_error(
+            errors,
+            f"{path.relative_to(root)}: Hermes tap skills must be immediate children of skills/",
+        )
+    immediate_dirs = sorted(
+        path for path in skills_root.iterdir() if path.is_dir() and not path.name.startswith(".")
+    )
+    return immediate_dirs
+
+
+def validate_secrets(root: Path, errors: list[str]) -> None:
     fragments = [
         ("private key", "-----BEGIN " + "PRIVATE KEY-----"),
         ("OpenAI-style key", "sk-" + "proj-"),
@@ -361,66 +406,78 @@ def validate_secrets(errors: list[str]) -> None:
         ("Slack token", "xox" + "b-"),
     ]
     aws_pattern = re.compile(r"\bAKIA[0-9A-Z]{16}\b")
+    assigned_pattern = re.compile(
+        r"(?i)(api[_-]?key|secret|token)\s*[:=]\s*['\"][A-Za-z0-9+/=_-]{20,}"
+    )
     ignored_parts = {".git", "__pycache__", ".venv", "node_modules"}
-
-    for path in ROOT.rglob("*"):
+    for path in root.rglob("*"):
         if not path.is_file() or any(part in ignored_parts for part in path.parts):
             continue
         try:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        relative = path.relative_to(ROOT)
+        relative = path.relative_to(root)
         for label, marker in fragments:
             if marker in content:
-                fail(errors, f"{relative}: possible {label}")
+                add_error(errors, f"{relative}: possible {label}")
         if aws_pattern.search(content):
-            fail(errors, f"{relative}: possible AWS access key")
-        if re.search(r"(?i)(api[_-]?key|secret|token)\s*[:=]\s*['\"][A-Za-z0-9+/=_-]{20,}", content):
-            fail(errors, f"{relative}: possible assigned secret")
+            add_error(errors, f"{relative}: possible AWS access key")
+        if assigned_pattern.search(content):
+            add_error(errors, f"{relative}: possible assigned secret")
 
 
-def main() -> int:
+def validate_repository(root: Path) -> list[str]:
+    root = root.resolve()
     errors: list[str] = []
-
     for required in sorted(REQUIRED_ROOT_FILES):
-        if not (ROOT / required).exists():
-            fail(errors, f"Missing required repository file: {required}")
+        if not (root / required).exists():
+            add_error(errors, f"Missing required repository file: {required}")
+    for path in sorted(root.rglob("*.json")):
+        load_json(root, path, errors)
 
-    for path in sorted(ROOT.rglob("*.json")):
-        load_json(path, errors)
-
-    catalog = load_json(ROOT / "catalog.json", errors)
-    catalog_by_path = validate_catalog(catalog, errors)
-
-    skill_files = sorted((ROOT / "skills").glob("*/*/SKILL.md"))
-    discovered_paths = {
-        skill_file.parent.relative_to(ROOT).as_posix()
-        for skill_file in skill_files
-    }
-
-    for skill_file in skill_files:
-        directory = skill_file.parent
-        relative = directory.relative_to(ROOT).as_posix()
-        validate_skill(directory, catalog_by_path.get(relative), errors)
-
+    catalog = load_json(root, root / "catalog.json", errors)
+    catalog_by_path, _ = validate_catalog(catalog, errors)
+    immediate_dirs = validate_tap_layout(root, errors)
+    discovered_paths: set[str] = set()
+    for directory in immediate_dirs:
+        relative = directory.relative_to(root).as_posix()
+        discovered_paths.add(relative)
+        validate_skill(root, directory, catalog_by_path.get(relative), errors)
     for catalog_path in catalog_by_path:
         if catalog_path not in discovered_paths:
-            fail(errors, f"catalog.json points to missing skill directory: {catalog_path}")
+            add_error(errors, f"catalog.json points to missing skill directory: {catalog_path}")
+    validate_secrets(root, errors)
+    return errors
 
-    validate_secrets(errors)
 
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root to validate (defaults to this checkout).",
+    )
+    args = parser.parse_args(argv)
+    errors = validate_repository(args.root)
     if errors:
         print(f"Validation failed with {len(errors)} error(s):")
         for error in errors:
             print(f"  - {error}")
         return 1
-
+    published = len(
+        [
+            directory
+            for directory in (args.root / "skills").iterdir()
+            if directory.is_dir() and (directory / "SKILL.md").is_file()
+        ]
+    )
     print(
         "Validation passed: "
-        f"{len(discovered_paths)} published skill(s), "
-        f"{len(list(ROOT.rglob('*.json')))} JSON file(s), "
-        "no common secret patterns detected."
+        f"{published} published skill(s), "
+        f"{len(list(args.root.rglob('*.json')))} JSON file(s), "
+        "tap layout compatible, no common secret patterns detected."
     )
     return 0
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,11 +1,11 @@
 # Published skills
 
-This directory is intentionally empty during repository foundation review.
+This directory is intentionally empty during repository hardening.
 
-Published skills will use:
+Hermes tap discovery expects each published skill directly beneath `skills/`:
 
 ```text
-skills/<category>/<skill-name>/
+skills/<skill-name>/
 ├── SKILL.md
 ├── README.md
 ├── examples/
@@ -13,4 +13,6 @@ skills/<category>/<skill-name>/
     └── cases.json
 ```
 
-Do not add a skill directly without first opening a **Skill proposal** issue and satisfying the admission rule in the root README.
+Do not insert category folders. Categories belong in `metadata.hermes.category` and `catalog.json`.
+
+Do not add a skill without a **Skill proposal** issue and the admission evidence required by the root README.

--- a/templates/skill-template/README.md
+++ b/templates/skill-template/README.md
@@ -2,10 +2,11 @@
 
 This directory is a **nonfunctional authoring scaffold**, not a published skill.
 
-Copy it to `skills/<category>/<real-skill-name>/`, replace every placeholder, add real examples and tests, then run:
+Copy it directly to `skills/<real-skill-name>/`, replace every placeholder, add real examples and tests, then run:
 
 ```bash
 python scripts/validate.py
+python -m unittest discover -s tests -v
 ```
 
-A copied template is not eligible for review until it satisfies the admission rule and the complete skill specification.
+Do not place the copied skill inside a category directory. Category belongs in frontmatter and the catalog.

--- a/templates/skill-template/SKILL.md
+++ b/templates/skill-template/SKILL.md
@@ -7,17 +7,18 @@ license: Apache-2.0
 platforms: [platform-agnostic]
 metadata:
   hermes:
+    category: replace-with-category
     tags: [replace-me]
     related_skills: []
 ---
 
 # Replace with Skill Title
 
-> TEMPLATE ONLY. Replace every placeholder before moving this directory under `skills/`.
+> TEMPLATE ONLY. Replace every placeholder before moving this directory to `skills/<skill-name>/`.
 
 ## Overview
 
-Describe the recurring real-world task and the process discipline this skill adds.
+Describe the recurring task and the process discipline this skill adds.
 
 ## When to Use
 
@@ -35,7 +36,7 @@ Do not use this skill when:
 
 ## Common Pitfalls
 
-1. **REPLACE_WITH_A_FAILURE MODE.** Explain the correction.
+1. **REPLACE_WITH_A_FAILURE_MODE.** Explain the correction.
 
 ## Verification Checklist
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate.py"
+SPEC = importlib.util.spec_from_file_location("field_kit_validate", MODULE_PATH)
+assert SPEC and SPEC.loader
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+SKILL_BODY = """---
+name: example-skill
+description: Use when a repeatable example workflow needs disciplined execution.
+version: 0.1.0
+author: Test Author
+license: Apache-2.0
+platforms: [platform-agnostic]
+metadata:
+  hermes:
+    category: testing
+    tags: [example, testing]
+    related_skills: []
+---
+
+# Example Skill
+
+## Overview
+A minimal test skill.
+
+## When to Use
+Use it for tests. Do not use it outside tests.
+
+## Workflow
+1. Perform the test and verify an observable result.
+
+## Common Pitfalls
+1. Skipping validation.
+
+## Verification Checklist
+- [ ] The result is observable.
+"""
+
+TEST_CASES = {
+    "schema_version": "1.0",
+    "cases": [
+        {
+            "id": "positive-trigger",
+            "type": "positive-trigger",
+            "prompt": "Run the example workflow.",
+            "expect": ["Uses the documented workflow"],
+        }
+    ],
+}
+
+
+class RepositoryFactory:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        required = validator.REQUIRED_ROOT_FILES
+        for relative in required:
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if relative == "catalog.json":
+                path.write_text(
+                    json.dumps({"schema_version": "1.0", "skills": []}),
+                    encoding="utf-8",
+                )
+            elif relative.endswith(".json"):
+                path.write_text("{}", encoding="utf-8")
+            else:
+                path.write_text(f"fixture for {relative}\n", encoding="utf-8")
+        (root / "skills").mkdir(exist_ok=True)
+
+    def add_skill(self, *, nested: bool = False, catalog: bool = True) -> Path:
+        directory = self.root / "skills" / (
+            "testing/example-skill" if nested else "example-skill"
+        )
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "SKILL.md").write_text(SKILL_BODY, encoding="utf-8")
+        (directory / "README.md").write_text("# Example\n", encoding="utf-8")
+        (directory / "examples").mkdir()
+        (directory / "examples" / "README.md").write_text(
+            "# Examples\n", encoding="utf-8"
+        )
+        (directory / "tests").mkdir()
+        (directory / "tests" / "cases.json").write_text(
+            json.dumps(TEST_CASES), encoding="utf-8"
+        )
+        if catalog:
+            self.set_catalog(
+                [
+                    {
+                        "name": "example-skill",
+                        "category": "testing",
+                        "path": "skills/example-skill",
+                        "version": "0.1.0",
+                        "description": "Use when a repeatable example workflow needs disciplined execution.",
+                        "platforms": ["platform-agnostic"],
+                        "status": "experimental",
+                    }
+                ]
+            )
+        return directory
+
+    def set_catalog(self, skills: list[dict]) -> None:
+        (self.root / "catalog.json").write_text(
+            json.dumps({"schema_version": "1.0", "skills": skills}),
+            encoding="utf-8",
+        )
+
+
+class ValidatorTests(unittest.TestCase):
+    def make_repo(
+        self,
+    ) -> tuple[tempfile.TemporaryDirectory[str], RepositoryFactory]:
+        temp = tempfile.TemporaryDirectory()
+        return temp, RepositoryFactory(Path(temp.name))
+
+    def assert_error_contains(self, errors: list[str], text: str) -> None:
+        self.assertTrue(
+            any(text in error for error in errors),
+            f"Expected {text!r} in {errors}",
+        )
+
+    def test_valid_minimal_tap_skill(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            repo.add_skill()
+            self.assertEqual([], validator.validate_repository(repo.root))
+
+    def test_nested_category_layout_is_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            repo.add_skill(nested=True)
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "immediate children of skills/")
+
+    def test_missing_skill_md_is_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            directory = repo.add_skill()
+            (directory / "SKILL.md").unlink()
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "SKILL.md is required")
+
+    def test_catalog_only_entry_is_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            repo.set_catalog(
+                [
+                    {
+                        "name": "ghost-skill",
+                        "category": "testing",
+                        "path": "skills/ghost-skill",
+                        "version": "0.1.0",
+                        "description": "Use when a ghost fixture is needed.",
+                        "platforms": ["platform-agnostic"],
+                        "status": "experimental",
+                    }
+                ]
+            )
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "points to missing skill directory")
+
+    def test_skill_without_catalog_entry_is_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            repo.add_skill(catalog=False)
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "missing catalog.json entry")
+
+    def test_mismatched_metadata_path_and_version_are_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            repo.add_skill()
+            base = {
+                "name": "example-skill",
+                "category": "testing",
+                "path": "skills/example-skill",
+                "version": "0.1.0",
+                "description": "Use when a repeatable example workflow needs disciplined execution.",
+                "platforms": ["platform-agnostic"],
+                "status": "experimental",
+            }
+
+            wrong_path = dict(base, path="skills/wrong-path")
+            repo.set_catalog([wrong_path])
+            self.assert_error_contains(
+                validator.validate_repository(repo.root),
+                ".path must be skills/example-skill",
+            )
+
+            wrong_category = dict(base, category="wrong-category")
+            repo.set_catalog([wrong_category])
+            self.assert_error_contains(
+                validator.validate_repository(repo.root),
+                "catalog category does not match SKILL.md",
+            )
+
+            wrong_version = dict(base, version="9.9.9")
+            repo.set_catalog([wrong_version])
+            self.assert_error_contains(
+                validator.validate_repository(repo.root),
+                "catalog version does not match SKILL.md",
+            )
+
+    def test_invalid_frontmatter_is_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            directory = repo.add_skill()
+            (directory / "SKILL.md").write_text("name: broken\n", encoding="utf-8")
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "must start with '---' at byte zero")
+
+    def test_missing_test_cases_are_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            directory = repo.add_skill()
+            (directory / "tests" / "cases.json").unlink()
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "tests/cases.json is required")
+
+    def test_duplicate_catalog_names_are_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            repo.add_skill()
+            catalog = json.loads(
+                (repo.root / "catalog.json").read_text(encoding="utf-8")
+            )
+            catalog["skills"].append(dict(catalog["skills"][0]))
+            repo.set_catalog(catalog["skills"])
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "Duplicate skill name in catalog")
+
+    def test_secret_like_content_is_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            directory = repo.add_skill()
+            marker = "gh" + "p_" + "A" * 36
+            (directory / "examples" / "bad.txt").write_text(
+                marker, encoding="utf-8"
+            )
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "possible GitHub token")
+
+    def test_unsafe_support_path_is_rejected(self) -> None:
+        temp, repo = self.make_repo()
+        with temp:
+            directory = repo.add_skill()
+            (directory / "hooks").mkdir()
+            (directory / "hooks" / "post-install.sh").write_text(
+                "echo nope\n", encoding="utf-8"
+            )
+            errors = validator.validate_repository(repo.root)
+            self.assert_error_contains(errors, "unsupported skill path")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -223,7 +223,7 @@ class ValidatorTests(unittest.TestCase):
             directory = repo.add_skill()
             (directory / "tests" / "cases.json").unlink()
             errors = validator.validate_repository(repo.root)
-            self.assert_error_contains(errors, "tests/cases.json is required")
+            self.assert_error_contains(errors, "cases.json is required")
 
     def test_duplicate_catalog_names_are_rejected(self) -> None:
         temp, repo = self.make_repo()


### PR DESCRIPTION
## Summary

Completes the pre-skill compatibility and hardening pass without adding a published skill.

## Compatibility

- Changes the published layout from `skills/<category>/<name>/` to the Hermes tap-discoverable `skills/<name>/`
- Preserves category organization through `metadata.hermes.category` and `catalog.json`
- Updates the catalog schema, template, installation flow, contribution rules, and release checklist
- Adds explicit validation that nested category layouts are rejected

## Validator contract

Adds an isolated `unittest` suite that proves acceptance of a valid minimal tap skill and rejection of:

- Nested category layout
- Missing `SKILL.md`
- Catalog-only entries
- Skill-only directories
- Mismatched path, category, and version
- Invalid frontmatter
- Missing test cases
- Duplicate names
- Secret-like content
- Unsupported supporting paths

## CI hardening

- Pins `actions/checkout` and `actions/setup-python` to verified immutable commit SHAs
- Disables persisted checkout credentials
- Keeps the token read-only
- Adds concurrency cancellation and 10-minute job timeouts
- Runs validator contract tests before repository validation
- Adds weekly Dependabot updates for GitHub Actions

## Local validation

```text
Ran 11 tests in 0.524s
OK
```

## Deliberate exclusions

- No real skills
- No release or tag
- No `skills.sh.json` while the catalog is empty
- Repository settings and ruleset changes are tracked separately because they are GitHub control-plane settings, not versioned files
