### PR TITLE
docs: state that private vulnerability reporting is enabled

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Do not open a public issue for:
 - A validation bypass that could expose users
 - A skill that performs consequential actions without adequate boundaries
 
-Use GitHub's private vulnerability reporting feature when available. If it is not available, contact the maintainer privately through the contact method on the maintainer's GitHub profile.
+Use GitHub's private vulnerability reporting feature, which is enabled for this repository. If you cannot use it, contact the maintainer privately through the contact method on the maintainer's GitHub profile.
 
 Include:
 


### PR DESCRIPTION
## Summary

GitHub private vulnerability reporting is now enabled for this repository. Updates SECURITY.md to state this directly instead of the conditional language used before the setting was available.

## Verification

- `python scripts/validate.py` passes
- `python -m unittest discover -s tests -v` (11/11) passes