### PR TITLE
docs: correct v1.0.1 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on Keep a Changelog, and the project uses Semantic Versionin
 
 No unreleased changes.
 
-## [1.0.1] - 2026-07-23
+## [1.0.1] - 2026-07-24
 
 ### Fixed
 


### PR DESCRIPTION
Correct the v1.0.1 changelog date to the actual publication date, July 24, 2026. The full repository validation gate passes unchanged.